### PR TITLE
Refactor to use an object to carry cancellation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-release

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -155,11 +155,13 @@ export default Mixin.create({
   scheduleTask(queue, callbackOrName, ...args) {
     assert(`Called \`scheduleTask\` without a string as the first argument on ${this}.`, typeof queue === 'string');
     assert(`Called \`scheduleTask\` on destroyed object: ${this}.`, !this.isDestroyed);
+
     let type = typeof callbackOrName;
+    let pendingTimers = this._getOrAllocateArray('_pendingTimers');
 
     let cancelId = run.schedule(queue, this, () => {
-      let cancelIndex = this._pendingTimers.indexOf(cancelId);
-      this._pendingTimers.splice(cancelIndex, 1);
+      let cancelIndex = pendingTimers.indexOf(cancelId);
+      pendingTimers.splice(cancelIndex, 1);
 
       if (type === 'function') {
         callbackOrName.call(this, ...args);
@@ -170,7 +172,7 @@ export default Mixin.create({
       }
     });
 
-    this._pendingTimers.push(cancelId);
+    pendingTimers.push(cancelId);
     return cancelId;
   },
 

--- a/addon/mixins/run.js
+++ b/addon/mixins/run.js
@@ -127,6 +127,54 @@ export default Mixin.create({
   },
 
   /**
+   Adds the provided function to the named queue to be executed at the end of the RunLoop.
+   The timer is properly canceled if the object is destroyed before it is invoked.
+
+   Example:
+
+   ```js
+   import Component from 'ember-component';
+   import ContextBoundTasksMixin from 'web-client/mixins/context-bound-tasks';
+
+   export default Component.extend(ContextBoundTasksMixin, {
+     init() {
+       this._super(...arguments);
+       this.scheduleTask('afterRender', () => {
+         console.log('This runs at the end of the run loop (via the afterRender queue) if this component is still displayed');
+       })
+     }
+   });
+   ```
+
+   @method scheduleTask
+   @param { Function } callback the callback to run at the provided time
+   @param { ...* } args arguments to pass to the callback
+   @param { Number } [timeout=0] the time in the future to run the callback
+   @public
+   */
+  scheduleTask(queue, callbackOrName, ...args) {
+    assert(`Called \`scheduleTask\` without a string as the first argument on ${this}.`, typeof queue === 'string');
+    assert(`Called \`scheduleTask\` on destroyed object: ${this}.`, !this.isDestroyed);
+    let type = typeof callbackOrName;
+
+    let cancelId = run.schedule(queue, this, () => {
+      let cancelIndex = this._pendingTimers.indexOf(cancelId);
+      this._pendingTimers.splice(cancelIndex, 1);
+
+      if (type === 'function') {
+        callbackOrName.call(this, ...args);
+      } else if (type === 'string' && this[callbackOrName]) {
+        this[callbackOrName](...args);
+      } else {
+        throw new Error('You must pass a callback function or method name to `scheduleTask`.');
+      }
+    });
+
+    this._pendingTimers.push(cancelId);
+    return cancelId;
+  },
+
+  /**
    Runs the function with the provided name after the timeout has expired on the last
    invocation. The timer is properly canceled if the object is destroyed before it is
    invoked.

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-lts-2.8',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,6 +3,22 @@ module.exports = {
   useYarn: true,
   scenarios: [
     {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -201,7 +201,7 @@ test('scheduleTask tasks can be canceled', function(assert) {
       hasRun = true;
     });
 
-    run.cancel(timer);
+    subject.cancelTask(timer);
   });
 
   assert.notOk(hasRun, 'callback should have been canceled previously');

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -135,33 +135,32 @@ test('runTask tasks can be canceled', function(assert) {
 });
 
 test('scheduleTask invokes async tasks', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   let subject = this.subject();
-  let done = assert.async();
   let hasRun = false;
 
   run(() => {
     subject.scheduleTask('actions', () => {
       hasRun = true;
       assert.ok(true, 'callback was called');
-      done();
     });
 
     assert.notOk(hasRun, 'callback should not have run yet');
   });
+
+  assert.ok(hasRun, 'callback was called');
 });
 
 test('scheduleTask invokes named functions as async tasks', function(assert) {
-  assert.expect(4);
-  let done = assert.async();
+  assert.expect(5);
+
   let subject = this.subject({
     run(name) {
       hasRun = true;
       assert.equal(this, subject, 'context is correct');
       assert.equal(name, 'foo', 'passed arguments are correct');
       assert.ok(true, 'callback was called');
-      done();
     }
   });
   let hasRun = false;
@@ -170,12 +169,13 @@ test('scheduleTask invokes named functions as async tasks', function(assert) {
     subject.scheduleTask('sync', 'run', 'foo');
     assert.notOk(hasRun, 'callback should not have run yet');
   });
+
+  assert.ok(hasRun, 'callback was called');
 });
 
 test('cancels tasks added with `scheduleTask`', function(assert) {
   assert.expect(2);
   let subject = this.subject();
-  let done = assert.async();
   let hasRun = false;
 
   run(() => {
@@ -188,16 +188,12 @@ test('cancels tasks added with `scheduleTask`', function(assert) {
     run(subject, 'destroy');
   });
 
-  window.setTimeout(() => {
-    assert.notOk(hasRun, 'callback should not have run yet');
-    done();
-  }, 10);
+  assert.notOk(hasRun, 'callback should not have run yet');
 });
 
 test('scheduleTask tasks can be canceled', function(assert) {
   assert.expect(1);
   let subject = this.subject();
-  let done = assert.async();
   let hasRun = false;
 
   run(() => {
@@ -208,10 +204,7 @@ test('scheduleTask tasks can be canceled', function(assert) {
     run.cancel(timer);
   });
 
-  window.setTimeout(() => {
-    assert.notOk(hasRun, 'callback should have been canceled previously');
-    done();
-  }, 10);
+  assert.notOk(hasRun, 'callback should have been canceled previously');
 });
 
 test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {


### PR DESCRIPTION
A few impacts from this:

* Avoid iterating a list of pending timers for each cancellation attempt by passing around an object with cancellation attached.
* Add a check on `isDestroyed` to each uncancelled task. That way there is no need to explicitly cancel them.
* Create dictionaries with null prototypes.
* Eagerly check the type of the call being registered so we an throw an error then.
* Build a single queue of all tasks for a given runloop queue and flush all scheduled tasks in a single runloop queue'd task. We're not using the runloops cancellation here so no need to have a separate runloop task for each scheduled task.

FYI

* I didn't update the docs. I don't suggest making the API of the returned object public API. If we could use ES symbols for the methods `cancel` and `task` I'd suggest doing that.
* I don't recall if the runloop itself already does some of this style of optimization- Last I knew it actually iterated to find your task and mark it cancelled instead of boxing like this.

Thanks for continuing to move this forward.